### PR TITLE
Update ROS_DISTRO to foxy in Dockerfile

### DIFF
--- a/ros2/Dockerfile
+++ b/ros2/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG ROS_DISTRO="galactic"
+ARG ROS_DISTRO="foxy"
 FROM ros:${ROS_DISTRO}-ros-base
 # Restate for later use
 ARG ROS_DISTRO


### PR DESCRIPTION
## Description

Resolves # (9)

This PR updates the Dockerfile to use the foxy ROS2 distro.

## Testing

The changes were testing by going through the README.md and building the Dockerfile.

## Notes
