### PR TITLE
Changed functions in PathGenerator to private

### DIFF
--- a/functional_programming_tests/test/with_parameter_factory.cpp
+++ b/functional_programming_tests/test/with_parameter_factory.cpp
@@ -133,6 +133,7 @@ struct PathGenerator : public rclcpp::Node {
                   std::placeholders::_1, std::placeholders::_2));
   }
 
+private:
   void set_map_service(
       const std::shared_ptr<example_srvs::srv::SetMap::Request> request,
       std::shared_ptr<example_srvs::srv::SetMap::Response> response) {
@@ -199,7 +200,6 @@ struct PathGenerator : public rclcpp::Node {
     response->path = response_path;
   }
 
- private:
   // Function that sets costmap
   bool set_costmap(const std_msgs::msg::UInt8MultiArray& costmap) {  // Action
     // Get the costmap from a ros topic

--- a/functional_programming_tests/test/with_parameter_factory.cpp
+++ b/functional_programming_tests/test/with_parameter_factory.cpp
@@ -133,7 +133,7 @@ struct PathGenerator : public rclcpp::Node {
                   std::placeholders::_1, std::placeholders::_2));
   }
 
-private:
+ private:
   void set_map_service(
       const std::shared_ptr<example_srvs::srv::SetMap::Request> request,
       std::shared_ptr<example_srvs::srv::SetMap::Response> response) {

--- a/functional_programming_tests/test/with_parameters.cpp
+++ b/functional_programming_tests/test/with_parameters.cpp
@@ -122,6 +122,7 @@ class PathGenerator : public rclcpp::Node {
                   std::placeholders::_1, std::placeholders::_2));
   }
 
+ private:
   void set_map_service(
       const std::shared_ptr<example_srvs::srv::SetMap::Request> request,
       std::shared_ptr<example_srvs::srv::SetMap::Response> response) {
@@ -188,7 +189,6 @@ class PathGenerator : public rclcpp::Node {
     response->path = response_path;
   }
 
- private:
   // Function that sets costmap
   bool set_costmap(const std_msgs::msg::UInt8MultiArray& costmap) {  // Action
     // Get the costmap from a ros topic

--- a/functional_programming_tests/test/without_functional_programming.cpp
+++ b/functional_programming_tests/test/without_functional_programming.cpp
@@ -63,6 +63,7 @@ class PathGenerator : public rclcpp::Node {
                   std::placeholders::_1, std::placeholders::_2));
   }
 
+ private:
   void set_map_service(
       const std::shared_ptr<example_srvs::srv::SetMap::Request> request,
       std::shared_ptr<example_srvs::srv::SetMap::Response> response) {
@@ -129,7 +130,6 @@ class PathGenerator : public rclcpp::Node {
     response->path = response_path;
   }
 
- private:
   // Function that sets costmap
   bool set_costmap(const std_msgs::msg::UInt8MultiArray& costmap) {  // Action
     // Get the costmap from a ros topic


### PR DESCRIPTION
## Description

Changed service callbacks in `PathGenerator` to private across all test files.

## Testing

Launch Docker container and run

```
colcon build
```
Ensure that there are no errors. 
